### PR TITLE
add externalPluginRegistry: true

### DIFF
--- a/cluster-init/ocp-4.4/operator-crw-cr.yaml
+++ b/cluster-init/ocp-4.4/operator-crw-cr.yaml
@@ -8,6 +8,7 @@ spec:
     cheImageTag: ''
     cheFlavor: codeready
     devfileRegistryImage: ''
+    externalPluginRegistry: true 
     pluginRegistryImage: 'quay.io/lbroudoux/che-plugin-registry:master'
     tlsSupport: true
     selfSignedCert: false


### PR DESCRIPTION
Prevent deployment of default plugin registry https://access.redhat.com/documentation/en-us/red_hat_codeready_workspaces/2.3/html/installation_guide/configuring-the-codeready-workspaces-installation_crw#checluster-custom-resources-fields-reference_configuring-the-codeready-workspaces-installation